### PR TITLE
[TS] Debug Prompt 4 - Front End Infrastructure

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -192,7 +192,6 @@ $productMenuWidth: 320px;
 				max-height: calc(
 					100vh - #{$controlMenuHeight + $portletLayoutMargin} - #{$toolbarHeight}
 				);
-				overflow: auto;
 
 				@include media-breakpoint-up(lg) {
 					max-height: calc(


### PR DESCRIPTION
When accessing the 'Structures' tab under Web Content, when the user added enough fields to enable scrolling, the left side of the screen was unable to scroll. Upon further inspection, this error was caused by a lack of padding for the left side of the screen which was impacted by the fields content window that automatically created an inner scroll wheel. This would essentially lock the inside fields window to have very small padding on the left and right sides - it created two separate scroll wheels when the right tool panel was closed - one for the entire page, and one for the fields content panel. By removing the overflow feature, it unlocks the scrolling, creating only one scrollbar instead of two thus allowing the left and right sides to scroll.