### PR TITLE
[TS] Debug Prompt 5 - USM

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountGroupsManagementToolbarDisplayContext.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/display/context/ViewAccountGroupsManagementToolbarDisplayContext.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -153,9 +154,17 @@ public class ViewAccountGroupsManagementToolbarDisplayContext
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		return PortalPermissionUtil.contains(
-			themeDisplay.getPermissionChecker(),
-			AccountActionKeys.ADD_ACCOUNT_GROUP);
+		if (PortalPermissionUtil.contains(
+				themeDisplay.getPermissionChecker(),
+				AccountActionKeys.ADD_ACCOUNT_GROUP))
+
+			return true;
+			else
+
+			return AccountGroupPermission.contains(
+				themeDisplay.getPermissionChecker(),
+				ParamUtil.getLong(liferayPortletRequest, "accountGroupId"),
+				ActionKeys.UPDATE);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountGroupDetailsScreenNavigationCategory.java
+++ b/modules/apps/account/account-admin-web/src/main/java/com/liferay/account/admin/web/internal/frontend/taglib/servlet/taglib/AccountGroupDetailsScreenNavigationCategory.java
@@ -17,6 +17,7 @@ package com.liferay.account.admin.web.internal.frontend.taglib.servlet.taglib;
 import com.liferay.account.admin.web.internal.constants.AccountScreenNavigationEntryConstants;
 import com.liferay.account.admin.web.internal.display.AccountGroupDisplay;
 import com.liferay.account.admin.web.internal.security.permission.resource.AccountGroupPermission;
+import com.liferay.account.constants.AccountActionKeys;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationCategory;
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 
 import java.io.IOException;
 
@@ -74,9 +76,16 @@ public class AccountGroupDetailsScreenNavigationCategory
 	public boolean isVisible(
 		User user, AccountGroupDisplay accountGroupDisplay) {
 
-		return AccountGroupPermission.contains(
-			PermissionCheckerFactoryUtil.create(user),
-			accountGroupDisplay.getAccountGroupId(), ActionKeys.UPDATE);
+		if (AccountGroupPermission.contains(
+				PermissionCheckerFactoryUtil.create(user),
+				accountGroupDisplay.getAccountGroupId(), ActionKeys.UPDATE))
+
+			return true;
+			else
+
+			return PortalPermissionUtil.contains(
+				PermissionCheckerFactoryUtil.create(user),
+				AccountActionKeys.ADD_ACCOUNT_GROUP);
 	}
 
 	@Override


### PR DESCRIPTION
Fixed error relating to Roles -> Account Groups:

When a user is granted the permission to 'Add Account Groups', the option to enter the screen is available but the Add page is blank, showing that they are denied permission. However, when the user is granted the 'Update Account Groups' permission, they were able to view the Add page and add groups accordingly.

After reviewing the code, the creation menu was only being displayed to users with the 'Update Account Groups' permission. So, this fix added the ability to view this creation menu if the user has the 'Add Account Groups' permission. Now, any user with 'Add Account Groups' or 'Update Account Groups' can create an account group.

Also, the user was unable to see the '+' icon to get to the creation menu if they were only granted the 'Update Account Groups' permission. This was also fixed so that the '+' navigation icon is shown to users with either the 'Add Account Groups' or 'Update Account Groups' permission  