### PR TITLE
LPS-155839: Don't display web content template titles in escaped format

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
@@ -70,7 +70,7 @@ public class JournalDDMTemplateVerticalCard implements VerticalCard {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
@@ -129,7 +129,7 @@ public class JournalDDMTemplateVerticalCard extends BaseVerticalCard {
 
 	@Override
 	public String getTitle() {
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalSelectDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalSelectDDMTemplateVerticalCard.java
@@ -115,7 +115,7 @@ public class JournalSelectDDMTemplateVerticalCard implements VerticalCard {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155839

The issue is caused when the user creates a Template in Web Content. If the user used certain characters (such as _&_, _"_, _'_, _< >_, etc), the title of the Template would display correctly at the top, but once the user navigates back to the Templates page to view all of the templates, the titles would be displayed in escaped format. This bug was tracked to _JournalDDMTemplateVerticalCard.java_ where the _getName_ function for the Templates was being used. It was returning the HtmlUtil.escape format of the title, where it should just be returning the original title. This fixes that return statement and allows for the template titles to be displayed properly with any characters.