### PR TITLE
LPS-154801 Canonical URLS generating correctly when containing URL separators

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1395,6 +1395,11 @@ public class PortalImpl implements Portal {
 				parametersURL = completeURL.substring(pos);
 			}
 		}
+		else {
+			groupFriendlyURL = getGroupFriendlyURL(
+				layout.getLayoutSet(), themeDisplay, true,
+				layout.isTypeControlPanel());
+		}
 
 		if (layout == null) {
 			layout = themeDisplay.getLayout();
@@ -1428,10 +1433,6 @@ public class PortalImpl implements Portal {
 
 			canonicalLayoutFriendlyURL = defaultLayoutFriendlyURL;
 		}
-
-		groupFriendlyURL = getGroupFriendlyURL(
-			layout.getLayoutSet(), themeDisplay, true,
-			layout.isTypeControlPanel());
 
 		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
 			String groupFriendlyURLDomain = HttpComponentsUtil.getDomain(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154801

When viewing the canonical URL of a page with a custom link containing a URL separator, such as "/l/", the URL would be split up and displayed incorrectly. This issue was caused by the **getCanonicalURL()** method that was returning incorrect URLS.
The method returns **groupFriendlyURL**, which initially holds the correct value of the URL contents up to the URL separator, but upon reviewing where it is changed, it seemed that every time it went through being set to 

`getGroupFriendlyURL(layout.getLayoutSet(), themeDisplay, true, layout.isTypeControlPanel());`

it was returning as "`localhost:8000`". It would then combine itself with **parametersURL**, which contained the last half of the URL starting from the URL separator. So, the URL would return incorrectly, displaying everything in the URL from the URL separator forward. 

For example: 
`/resources/l/digital-strategy`
would return as
`/l/digital-strategy`

The change was created with the mindset that, if the URL is null, a groupFriendlyURL will be generated as before. This ensures that this code is only used when needed. If the URL is not null, then the groupFriendlyURL is initialized as normal and not overwritten.