### PR TITLE
LPS-154165 - Add Comment formatted the same as other buttons

### DIFF
--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/components/Answer.es.js
@@ -134,8 +134,8 @@ export default withRouter(
 												answer.status !== 'pending' &&
 												comments.length === 0 && (
 													<ClayButton
-														className="btn-sm c-px-2 c-py-1 text-reset text-secondary"
-														displayType="secondary"
+														className="text-reset"
+														displayType="unstyled"
 														onClick={() =>
 															setShowNewComment(
 																true


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154165
Due to recent changes, in a Questions widget, the button "Reply" was changed to "Add Comment", and also had a formatting update, giving it a different style than the other options. The LPS requested that all buttons have the same format, like they did before the changes.

Before all changes:
![image](https://user-images.githubusercontent.com/106186314/176047122-76129a91-09c6-46a5-9c63-1935a3722442.png)

After the recent updates:
![image](https://user-images.githubusercontent.com/106186314/176046687-2cdf24f9-3e1a-4650-9779-3cf39d8ad4bf.png)

After my formatting changes:
![image](https://user-images.githubusercontent.com/106186314/176046902-0708c602-9061-4dc6-8a2a-cd463f722f44.png)
