### PR TITLE
LPS-158932 Allow for userID to be passed correctly when using Experiences with Workflow

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -50,6 +50,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -363,10 +364,19 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 				LayoutStructure.of(data), targetLayout, fragmentEntryLinksMap,
 				entry.getValue());
 
-			_layoutPageTemplateStructureLocalService.
-				updateLayoutPageTemplateStructureData(
-					targetLayout.getGroupId(), targetLayout.getPlid(),
-					entry.getValue(), dataJSONObject.toString());
+			long userId = PrincipalThreadLocal.getUserId();
+
+			PrincipalThreadLocal.setName(targetLayout.getUserId());
+
+			try {
+				_layoutPageTemplateStructureLocalService.
+					updateLayoutPageTemplateStructureData(
+						targetLayout.getGroupId(), targetLayout.getPlid(),
+						entry.getValue(), dataJSONObject.toString());
+			}
+			finally {
+				PrincipalThreadLocal.setName(userId);
+			}
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-45997

While having workflow enabled and creating a new page with multiple experiences, once approved, the pages would appear as blank.
This was because only when workflow was enabled, and updateLayoutPageTemplateStructureData was called, a user ID of 0 was passed passed in to the _layoutPageTemplateStructureRelLocalService.addLayoutPageTemplateStructureRel method which threw an error saying that there cannot be a userId of 0. This caused the experiences to not display their changes made, despite being 'approved'. When tested with workflow disabled, the correct userID gets passed each time.
The userID was being retrieved with PrincipalThreadLocal.getUserId() . The solution was to go back to when we had a valid userID and pass it along to make sure that a correct one is used and set it back afterwards, as well as ensure that it is not used anywhere else during the process.
We found that before updateLayoutPageTemplateStructureData is called, targetLayout.getUserId() is used earlier in the same method to retrieve the current userID.
Since PrincipalThreadLocal is used later on and causes the error, we set the userID in PrincipalThreadLocal to the targetLayout.getUserId() and wrap the original call to updateLayoutPageTemplateStructureData in a try/finally to quickly set, use, and reset the userId back to what it was.
We found that the only other place that this userId is used during this execution is within Publications.
The worry was that if workflow and publications were to be eventually integrated, this issue could potentially pass the wrong userId.
This [PTR](https://issues.liferay.com/browse/PTR-3253) confirmed that since workflow does not work with publications, this fix can proceed safely.