### PR TITLE
LPS-158932 Allow for userID to be passed correctly when using Experiences with Workflow

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -106,11 +107,18 @@ public class LayoutWorkflowHandler extends BaseWorkflowHandler<Layout> {
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
+		long originalUserId = PrincipalThreadLocal.getUserId();
+
+		PrincipalThreadLocal.setName(userId);
+
 		try {
 			_layoutCopyHelper.copyLayout(draftLayout, layout);
 		}
 		catch (Exception exception) {
 			throw new PortalException(exception);
+		}
+		finally {
+			PrincipalThreadLocal.setName(originalUserId);
 		}
 
 		_layoutLocalService.updateStatus(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-45997

While having workflow enabled and creating a new page with multiple experiences, once approved, the pages would appear as blank.

This was because only when workflow was enabled, and **updateLayoutPageTemplateStructureData** was called, a user ID of 0 was passed passed in to the _layoutPageTemplateStructureRelLocalService.addLayoutPageTemplateStructureRel method which threw an error saying that there cannot be a userId of 0. This caused the experiences to not display their changes made, despite being 'approved'. When tested with workflow disabled, the correct userID gets passed each time.

The userID was being retrieved with **PrincipalThreadLocal.getUserId()** . The solution was to go back to when we had a valid userID and pass it along to make sure that a correct one is used and set it back afterwards, as well as ensure that it is not used anywhere else during the process.

We decided to pass in a valid userId to **_layoutCopyHelper.copyLayout(draftLayout, layout)** located in **LayoutWorkflowHandler.java**, which ensures that these changes are only called when workflow is enabled.

Testing resulted in confirming that with the applied changes, the behavior is very similar to publishing a page without workflow, passing the correct userId's when needed.

The worry was that if workflow and publications were to be eventually integrated, this issue could potentially pass the wrong userId.
This [PTR](https://issues.liferay.com/browse/PTR-3253) confirmed that since workflow does not work with publications, this fix can proceed safely.